### PR TITLE
workflow_dispatch & schedule on FetchSpreadsheets

### DIFF
--- a/.github/workflows/fetch_spreadsheets.yml
+++ b/.github/workflows/fetch_spreadsheets.yml
@@ -1,9 +1,7 @@
 name: FetchSpreadsheets
 
 on:
-  push:
-  pull_request:
-  pull_request_target:
+  workflow_dispatch:
   schedule:
     - cron:  '0 10 * * *'
 


### PR DESCRIPTION
Leaves the workflow FetchSpreadsheets with only workflow_dispatch and schedule.

- workflow_dispatch is just so it gets dispatched manually.
- schedule, so it runs at 10 am UTC each day.