### PR TITLE
Adding task to scrape daily glance cases

### DIFF
--- a/pipeline/pipeline/dashboard_pdf_scrapper.py
+++ b/pipeline/pipeline/dashboard_pdf_scrapper.py
@@ -33,6 +33,11 @@ def read_pdf(source_file_path):
 def extract_breakdown_positive_cases_date(positive_cases_page):
     return positive_cases_page.extract_text().split("\n")[1]
 
+def extract_ward_wise_positive_cases_glance_page(pdf_path, page):
+    pdf = read_pdf(pdf_path)
+    covid_glance_page = pdf.pages[page]
+    return pd.DataFrame(covid_glance_page.extract_table())
+
 
 def extract_wards_data_from_page(positive_cases_page):
     top_left_x = 295.2  # points

--- a/pipeline/pipeline/dashboard_pdf_scrapper.py
+++ b/pipeline/pipeline/dashboard_pdf_scrapper.py
@@ -33,10 +33,12 @@ def read_pdf(source_file_path):
 def extract_breakdown_positive_cases_date(positive_cases_page):
     return positive_cases_page.extract_text().split("\n")[1]
 
-def extract_ward_wise_positive_cases_glance_page(pdf_path, page):
+
+def extract_ward_wise_positive_cases_glance_page(pdf_path, page_index=1):
     pdf = read_pdf(pdf_path)
-    covid_glance_page = pdf.pages[page]
-    return pd.DataFrame(covid_glance_page.extract_table())
+    covid_glance_page = pdf.pages[page_index]
+    table = covid_glance_page.extract_table()
+    return pd.DataFrame(table[1:], columns=table[0])
 
 
 def extract_wards_data_from_page(positive_cases_page):

--- a/pipeline/pipeline/tasks/spreadsheets.py
+++ b/pipeline/pipeline/tasks/spreadsheets.py
@@ -114,9 +114,9 @@ class ExtractElderlyTableGSheetTask(luigi.ExternalTask):
 
 class ExtractDataFromPdfDashboardGSheetWrapper(luigi.WrapperTask):
     date = luigi.DateParameter(default=date.today())
-    elderly_page = luigi.IntParameter(default=22)
-    daily_case_growth_page = luigi.IntParameter(default=25)
-    positive_breakdown_index = luigi.IntParameter(default=22)
+    # elderly_page = luigi.IntParameter(default=22)
+    daily_case_growth_page = luigi.IntParameter(default=23)
+    positive_breakdown_index = luigi.IntParameter(default=20)
 
     def requires(self):
         yield ExtractWardPositiveBreakdownGSheetTask(
@@ -125,7 +125,24 @@ class ExtractDataFromPdfDashboardGSheetWrapper(luigi.WrapperTask):
         yield ExtractCaseGrowthTableGSheetTask(
             date=self.date, page=self.daily_case_growth_page
         )
-        yield ExtractElderlyTableGSheetTask(date=self.date, page=self.elderly_page)
+        # yield ExtractElderlyTableGSheetTask(date=self.date, page=self.elderly_page)
+
+class AllDataGSheetTask(luigi.WrapperTask):
+    date = luigi.DateParameter(default=date.today())
+    daily_case_growth_page = luigi.IntParameter(default=25)
+    positive_breakdown_index = luigi.IntParameter(default=22)
+    states_and_districts = luigi.DictParameter()
+
+    def requires(self):
+        yield ExtractWardPositiveBreakdownGSheetTask(
+            date=self.date, page_index=self.positive_breakdown_index
+        )
+        yield ExtractCaseGrowthTableGSheetTask(
+            date=self.date, page=self.daily_case_growth_page
+        )
+        yield HospitalizationSheetGSheetTask(
+            data=self.date, states_and_districts=self.states_and_districts
+        )
 
 
 class HospitalizationSheetGSheetTask(luigi.ExternalTask):

--- a/pipeline/pipeline/tasks/spreadsheets.py
+++ b/pipeline/pipeline/tasks/spreadsheets.py
@@ -72,7 +72,9 @@ class ExtractGlanceWardWisePositiveCases(luigi.ExternalTask):
             "ab+"
         ) as named_tmp_file:
             named_tmp_file.write(textio2binary(input_file))
-            scrap_df = extract_ward_wise_positive_cases_glance_page(named_tmp_file.name, page=self.page_index)
+            scrap_df = extract_ward_wise_positive_cases_glance_page(
+                named_tmp_file.name, page_index=self.page_index
+            )
             scrap_df["downloaded_for"] = self.date.strftime("%Y-%m-%d")
             result_df = pandas.concat([worksheet_df, scrap_df])
             self.response = worksheet.update(
@@ -84,6 +86,7 @@ class ExtractGlanceWardWisePositiveCases(luigi.ExternalTask):
 
     def complete(self):
         return self.response is not None
+
 
 class ExtractCaseGrowthTableGSheetTask(luigi.ExternalTask):
     date = luigi.DateParameter(default=date.today())
@@ -154,6 +157,7 @@ class ExtractDataFromPdfDashboardGSheetWrapper(luigi.WrapperTask):
             date=self.date, page=self.daily_case_growth_page
         )
         # yield ExtractElderlyTableGSheetTask(date=self.date, page=self.elderly_page)
+
 
 class AllDataGSheetTask(luigi.WrapperTask):
     date = luigi.DateParameter(default=date.today())


### PR DESCRIPTION
Fixes #22 

Scrapping task for the "Ward wise positive cases" table on the second page of the PDF dashboard