### PR TITLE
Deal with districts present in multiple states

### DIFF
--- a/backend/data/extract_covid19_india_data.py
+++ b/backend/data/extract_covid19_india_data.py
@@ -80,6 +80,8 @@ class ExtractCovid19IndiaData:
                         district_dict['state'] = state
                         if district.strip().lower()=='unknown':
                             district_dict['district'] = unknown_dict[state]
+                        elif district.strip().lower() in ["other state", "pratapgarh", "hamirpur", "balrampur", "aurangabad", "bilaspur"]:
+                            district_dict['district'] = district + " " + state
                         else:
                             district_dict['district'] = district
 

--- a/backend/data/extract_covid19_india_data.py
+++ b/backend/data/extract_covid19_india_data.py
@@ -81,7 +81,7 @@ class ExtractCovid19IndiaData:
                         if district.strip().lower()=='unknown':
                             district_dict['district'] = unknown_dict[state]
                         elif district.strip().lower() in ["other state", "pratapgarh", "hamirpur", "balrampur", "aurangabad", "bilaspur"]:
-                            district_dict['district'] = district + " " + state
+                            district_dict['district'] = district + " - " + state
                         else:
                             district_dict['district'] = district
 


### PR DESCRIPTION
Certain districts - hamirpur, aurangabad, pratapgarh, balrampur, bilaspur - are present in multiple states, causing duplication during RT calculation. This pull request fixes that by appending the state to the district name when these districts are encountered